### PR TITLE
Feature/#34 save match ids

### DIFF
--- a/backend/ezgg/src/main/java/com/matching/ezgg/api/controller/ApiController.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/api/controller/ApiController.java
@@ -1,6 +1,7 @@
 package com.matching.ezgg.api.controller;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,8 +38,8 @@ public class ApiController {
 
 	//테스트용-matchIds
 	@GetMapping("match/{puuid}")//TODO 테스트 컨트롤러. 배포시 삭제
-	public ResponseEntity<ArrayList<String>> getMatchIds(@PathVariable("puuid") String puuid) {
-		ArrayList<String> matchIds = apiService.getMemberMatchIds(puuid);
+	public ResponseEntity<List<String>> getMatchIds(@PathVariable("puuid") String puuid) {
+		List<String> matchIds = apiService.getMemberMatchIds(puuid);
 		return ResponseEntity.ok().body(matchIds);
 	}
 }

--- a/backend/ezgg/src/main/java/com/matching/ezgg/api/controller/ApiController.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/api/controller/ApiController.java
@@ -38,7 +38,7 @@ public class ApiController {
 	//테스트용-matchIds
 	@GetMapping("match/{puuid}")//TODO 테스트 컨트롤러. 배포시 삭제
 	public ResponseEntity<ArrayList<String>> getMatchIds(@PathVariable("puuid") String puuid) {
-		ArrayList<String> matchIds = apiService.getMatchIds(puuid);
+		ArrayList<String> matchIds = apiService.getMemberMatchIds(puuid);
 		return ResponseEntity.ok().body(matchIds);
 	}
 }

--- a/backend/ezgg/src/main/java/com/matching/ezgg/api/domain/memberInfo/entity/MemberInfo.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/api/domain/memberInfo/entity/MemberInfo.java
@@ -75,4 +75,8 @@ public class MemberInfo extends BaseEntity {
 		this.wins   = wins;
 		this.losses = losses;
 	}
+
+	public void updateMatchIds(List<String> matchIds) {
+		this.matchIds = matchIds;
+	}
 }

--- a/backend/ezgg/src/main/java/com/matching/ezgg/api/domain/memberInfo/repository/MemberInfoRepository.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/api/domain/memberInfo/repository/MemberInfoRepository.java
@@ -1,5 +1,6 @@
 package com.matching.ezgg.api.domain.memberInfo.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,4 +15,7 @@ public interface MemberInfoRepository extends JpaRepository<MemberInfo, Long> {
 	Optional<String> findPuuidByMemberId(Long memberId);
 
 	Optional<MemberInfo> findByPuuid(String puuid);
+
+	@Query("SELECT m.matchIds FROM MemberInfo m WHERE m.puuid = :puuid")
+	Optional<List<String>> findMatchIdsByPuuid(String puuid);
 }

--- a/backend/ezgg/src/main/java/com/matching/ezgg/api/service/ApiService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/api/service/ApiService.java
@@ -12,7 +12,6 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
-import com.matching.ezgg.api.domain.memberInfo.service.MemberInfoService;
 import com.matching.ezgg.api.dto.PuuidDto;
 import com.matching.ezgg.api.dto.WinRateNTierDto;
 import com.matching.ezgg.global.exception.RiotAccountNotFoundException;
@@ -31,23 +30,11 @@ public class ApiService {
 	private final RestTemplate krRestTemplate;
 	private final String apiKey;
 
-	private final MemberInfoService memberInfoService;
-
-	//Member에서 가져오기 전 임시 데이터
-	// MatchIdsDto matchIds = new MatchIdsDto(
-	// 	new ArrayList<>(Arrays.asList(
-	// 		"KR_7601768141", "KR_7601734513", "KR_7601705129", "KR_7601656394", "KR_7601613169",
-	// 		"KR_7600470456", "KR_7600434924", "KR_7600399950", "KR_7600362953", "KR_7600316442",
-	// 		"KR_7600285732", "KR_7600101729", "KR_7599633637", "KR_7599216701", "KR_7599167828",
-	// 		"KR_7599149069", "KR_7599089836", "KR_7599045765", "KR_7598920436", "KR_7598839696")));
-	// PuuidDto puuid = new PuuidDto("35XPfSvBPYGbS38jEmjVgCrLlZu-PO9yP5ajqMMH-Xec3o9nQ3PkqSBU7lAVQo1-Sa3e74aFxcpRPg");
-
 	public ApiService(@Qualifier("asia") RestTemplate asiaRestTemplate, @Qualifier("kr") RestTemplate krRestTemplate,
-		@Value("${api.key}") String apiKey, MemberInfoService memberInfoService) {
+		@Value("${api.key}") String apiKey) {
 		this.asiaRestTemplate = asiaRestTemplate;
 		this.krRestTemplate = krRestTemplate;
 		this.apiKey = apiKey;
-		this.memberInfoService = memberInfoService;
 	}
 
 	//riot/account/v1/accounts/by-riot-id/{riot-id}/{tag}?api_key=
@@ -107,11 +94,10 @@ public class ApiService {
 	}
 
 	//lol/match/v5/matches/by-puuid/{puuid}/ids?start=0&count=20&api_key=apiKey
-	public ArrayList<String> getMatchIds(String puuid) {
+	public ArrayList<String> getMemberMatchIds(String puuid) {
 		log.info("matchIds 조회 시작");
 
 		try {
-
 			String url = String.format(
 				"/lol/match/v5/matches/by-puuid/%s/ids?start=0&count=20&api_key=%s",
 				puuid, apiKey

--- a/backend/ezgg/src/main/java/com/matching/ezgg/global/exception/RiotMatchIdsNotFoundException.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/global/exception/RiotMatchIdsNotFoundException.java
@@ -1,0 +1,14 @@
+package com.matching.ezgg.global.exception;
+
+public class RiotMatchIdsNotFoundException extends BaseException {
+	private static final String FORMAT = "최근 랭크 경기 전적을 찾을 수 없습니다. (puuid: %s)";
+
+	public RiotMatchIdsNotFoundException(String puuid) {
+		super(String.format(FORMAT, puuid));
+	}
+
+	@Override
+	public int getStatusCode() {
+		return 404;
+	}
+}

--- a/backend/ezgg/src/main/java/com/matching/ezgg/matching/service/MatchingService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/matching/service/MatchingService.java
@@ -1,5 +1,7 @@
 package com.matching.ezgg.matching.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import com.matching.ezgg.api.domain.memberInfo.service.MemberInfoService;
@@ -20,14 +22,31 @@ public class MatchingService {
 	}
 
 	public void updateAllAttributesOfMember(String puuid){
+		// 티어, 승률 업데이트
 		memberInfoService.updateWinRateNTier(apiService.getMemberWinRateNTier(puuid));
 
-		//TODO match, recentTwentyMatch 업데이트
+		// matchIds 업데이트 후 새롭게 추가된 matchId 리스트 리턴
+		List<String> newlyAddedMatchIds = updateAndGetNewMatchIds(puuid, apiService.getMemberMatchIds(puuid));
+
+		//TODO match 각각 업데이트
+
+		//TODO recentTwentyMatch 업데이트
 
 	}
 
 	private void createEsMatchingDocument(){
 		//TODO
+	}
+
+	// 새롭게 추가된 matchId가 없으면 null리스트 리턴. 있으면 matchIds 업데이트 후 새롭게 저장된 matchId 리스트 리턴
+	public List<String> updateAndGetNewMatchIds(String puuid, List<String> fetchedMatchIds) {
+		List<String> newlyAddedMatchIds = memberInfoService.extractNewMatchIds(puuid, fetchedMatchIds);
+
+		if (newlyAddedMatchIds != null && !newlyAddedMatchIds.isEmpty()) {
+			memberInfoService.updateMatchIds(puuid, fetchedMatchIds);
+		}
+
+		return newlyAddedMatchIds;
 	}
 
 }


### PR DESCRIPTION
chore: 불필요한 의존성/주석 제거, 메서드명 일관되게 수정
feat: MatchIds 수령 api 예외처리 적용, 랭크 경기 matchId 만 수령하도록 수정, 로그 수정
feat: Riot API 호출 후 matchIds 동기화 및 저장 로직 구현