### PR TITLE
Feature/#58 unify transaction

### DIFF
--- a/backend/ezgg/src/main/java/com/matching/ezgg/api/domain/memberInfo/entity/MemberInfo.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/api/domain/memberInfo/entity/MemberInfo.java
@@ -27,7 +27,7 @@ public class MemberInfo extends BaseEntity {
 	@Column(name = "id")
 	private Long id;
 
-	@Column(name = "member_id", unique = false, nullable = false)
+	@Column(name = "member_id", unique = true, nullable = false)
 	private Long memberId;
 
 	@Column(name = "riot_username", unique = false, nullable = false)
@@ -69,14 +69,13 @@ public class MemberInfo extends BaseEntity {
 		this.losses = losses;
 	}
 
-	public void updateWinRateAndTier(String tier, String tierNum, int wins, int losses) {
+	public void update(String tier, String tierNum, int wins, int losses, List<String> fetchedMatchIds, boolean existsNewMatchIds){
 		this.tier = tier;
 		this.tierNum = tierNum;
 		this.wins = wins;
 		this.losses = losses;
-	}
-
-	public void updateMatchIds(List<String> matchIds) {
-		this.matchIds = matchIds;
+		if(existsNewMatchIds){
+			this.matchIds = fetchedMatchIds;
+		}
 	}
 }

--- a/backend/ezgg/src/main/java/com/matching/ezgg/api/domain/memberInfo/repository/MemberInfoRepository.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/api/domain/memberInfo/repository/MemberInfoRepository.java
@@ -18,6 +18,8 @@ public interface MemberInfoRepository extends JpaRepository<MemberInfo, Long> {
 
 	Optional<MemberInfo> findByPuuid(String puuid);
 
+	Optional<MemberInfo> findByMemberId(Long memberId);
+
 	// riotUsername과 riotTag를 동시에 일치하는 회원이 존재하는 지 확인
 	boolean existsByRiotUsernameAndRiotTag(String riotUsename, String riotTag);
 }

--- a/backend/ezgg/src/main/java/com/matching/ezgg/api/domain/memberInfo/service/MemberInfoService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/api/domain/memberInfo/service/MemberInfoService.java
@@ -43,22 +43,9 @@ public class MemberInfoService {
 		return memberInfoRepository.findByPuuid(puuid).orElseThrow(MemberInfoNotFoundException::new);
 	}
 
-	// MemberInfo에 tier, rank, wins, losses 업데이트
-	@Transactional
-	public void updateWinRateNTier(WinRateNTierDto winRateNTierDto) {
-		log.info("티어, 승률 업데이트 시작");
-
-		// db에서 memberInfo 가져오기
-		MemberInfo memberInfo = getMemberInfoByPuuid(winRateNTierDto.getPuuid());
-
-		memberInfo.updateWinRateAndTier(
-			winRateNTierDto.getTier(),
-			winRateNTierDto.getTierNum(),
-			winRateNTierDto.getWins(),
-			winRateNTierDto.getLosses()
-		); // 영속성 상태에서 Dirty Checking을 해 자동으로 db에 커밋됨
-
-		log.info("티어, 승률 업데이트 종료: {}{}", winRateNTierDto.getTier(), winRateNTierDto.getTierNum());
+	// memberId로 MemberInfo 조회
+	public MemberInfo getMemberInfoByMemberId(Long memberId) {
+		return memberInfoRepository.findByMemberId(memberId).orElseThrow(MemberInfoNotFoundException::new);
 	}
 
 	//member info 생성
@@ -86,21 +73,26 @@ public class MemberInfoService {
 		List<String> existingMatchIds = Optional.ofNullable(getMemberInfoByPuuid(puuid).getMatchIds())
 			.orElse(Collections.emptyList());
 
-		Set<String> existingMathIdSet = new HashSet<>(existingMatchIds);
+		Set<String> existingMatchIdSet = new HashSet<>(existingMatchIds);
 
 		return fetchedMatchIds.stream()
-			.filter(matchId -> !existingMathIdSet.contains(matchId))
+			.filter(matchId -> !existingMatchIdSet.contains(matchId))
 			.collect(Collectors.toList());
 	}
 
-	// MemberInfo에 matchIds 업데이트
 	@Transactional
-	public void updateMatchIds(String puuid, List<String> fetchedMatchIds) {
-		log.info("matchIds 업데이트 시작");
-		MemberInfo memberInfo = getMemberInfoByPuuid(puuid);
-		memberInfo.updateMatchIds(
-			fetchedMatchIds
+	public MemberInfo updateMemberInfo(Long memberId, WinRateNTierDto winRateNTierDto, List<String> fetchedMatchIds, boolean existsNewMatchIds){
+		log.info("MemberInfo 업데이트 시작");
+		MemberInfo memberInfo = getMemberInfoByMemberId(memberId);
+		memberInfo.update(
+			winRateNTierDto.getTier(),
+			winRateNTierDto.getTierNum(),
+			winRateNTierDto.getWins(),
+			winRateNTierDto.getLosses(),
+			fetchedMatchIds,
+			existsNewMatchIds
 		); // 영속성 상태에서 Dirty Checking을 해 자동으로 db에 커밋됨
-		log.info("matchIds 업데이트 종료");
+		log.info("MemberInfo 업데이트 종료");
+		return memberInfo;
 	}
 }

--- a/backend/ezgg/src/main/java/com/matching/ezgg/api/domain/recentTwentyMatch/entity/RecentTwentyMatch.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/api/domain/recentTwentyMatch/entity/RecentTwentyMatch.java
@@ -29,7 +29,7 @@ public class RecentTwentyMatch extends BaseEntity {
 	@Column(name = "id")
 	private Long id;
 
-	@Column(name = "member_id", unique = false, nullable = false)
+	@Column(name = "member_id", unique = true, nullable = false)
 	private Long memberId;
 
 	@Column(name = "sum_kills", unique = false, nullable = true)

--- a/backend/ezgg/src/main/java/com/matching/ezgg/matching/dto/MemberDataBundle.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/matching/dto/MemberDataBundle.java
@@ -6,8 +6,10 @@ import com.matching.ezgg.api.domain.recentTwentyMatch.entity.RecentTwentyMatch;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class MemberDataBundle {
 	private MemberInfo memberInfo;

--- a/backend/ezgg/src/main/java/com/matching/ezgg/matching/dto/MemberDataBundle.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/matching/dto/MemberDataBundle.java
@@ -1,0 +1,21 @@
+package com.matching.ezgg.matching.dto;
+
+import com.matching.ezgg.api.domain.memberInfo.entity.MemberInfo;
+import com.matching.ezgg.api.domain.recentTwentyMatch.entity.RecentTwentyMatch;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberDataBundle {
+	private MemberInfo memberInfo;
+	private RecentTwentyMatch recentTwentyMatch;
+
+	@Builder
+	public MemberDataBundle(MemberInfo memberInfo, RecentTwentyMatch recentTwentyMatch){
+		this.memberInfo = memberInfo;
+		this.recentTwentyMatch = recentTwentyMatch; // 한판도 안한 경우 빈 객체가 나옴
+	}
+}

--- a/backend/ezgg/src/main/java/com/matching/ezgg/matching/service/MatchingDataBulkSaveService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/matching/service/MatchingDataBulkSaveService.java
@@ -1,0 +1,59 @@
+package com.matching.ezgg.matching.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.matching.ezgg.api.domain.match.service.MatchService;
+import com.matching.ezgg.api.domain.memberInfo.entity.MemberInfo;
+import com.matching.ezgg.api.domain.memberInfo.service.MemberInfoService;
+import com.matching.ezgg.api.domain.recentTwentyMatch.entity.RecentTwentyMatch;
+import com.matching.ezgg.api.domain.recentTwentyMatch.service.RecentTwentyMatchService;
+import com.matching.ezgg.api.dto.MatchDto;
+import com.matching.ezgg.api.dto.RecentTwentyMatchDto;
+import com.matching.ezgg.api.dto.WinRateNTierDto;
+import com.matching.ezgg.matching.dto.MemberDataBundle;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MatchingDataBulkSaveService {
+	private final MemberInfoService memberInfoService;
+	private final MatchService matchService;
+	private final RecentTwentyMatchService recentTwentyMatchService;
+
+	@Transactional
+	public MemberDataBundle saveAllAggregatedData(
+		Long memberId,
+		WinRateNTierDto winRateNTierDto,
+		List<String> fetchedMatchIds,
+		List<MatchDto> matchDtoList,
+		RecentTwentyMatchDto recentTwentyMatchDto,
+		boolean existsNewMatchIds
+	) {
+		// memberInfo 업데이트
+		MemberInfo memberInfo = memberInfoService.updateMemberInfo(memberId, winRateNTierDto, fetchedMatchIds, existsNewMatchIds);
+
+		// matchInfo 업데이트
+		// 어떤 matchInfo 저장 중 에러가 나왔는지 판단하기 위해 saveAll 적용X
+		for (MatchDto matchDto : matchDtoList) {
+			matchService.save(matchDto);
+		}
+
+		// recentTwentyMatch 업데이트
+		RecentTwentyMatch recentTwentyMatch;
+		if (existsNewMatchIds) {
+			recentTwentyMatch = recentTwentyMatchService.upsertRecentTwentyMatch(recentTwentyMatchDto);
+		} else {
+			recentTwentyMatch = recentTwentyMatchService.getRecentTwentyMatchByMemberId(memberId);
+		}
+
+		return MemberDataBundle.builder()
+			.memberInfo(memberInfo)
+			.recentTwentyMatch(recentTwentyMatch)
+			.build();
+	}
+
+}

--- a/backend/ezgg/src/main/java/com/matching/ezgg/matching/service/MatchingDataBulkSaveService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/matching/service/MatchingDataBulkSaveService.java
@@ -9,11 +9,11 @@ import com.matching.ezgg.api.domain.match.service.MatchService;
 import com.matching.ezgg.api.domain.memberInfo.entity.MemberInfo;
 import com.matching.ezgg.api.domain.memberInfo.service.MemberInfoService;
 import com.matching.ezgg.api.domain.recentTwentyMatch.entity.RecentTwentyMatch;
+import com.matching.ezgg.api.domain.recentTwentyMatch.service.RecentTwentyMatchBuilderService;
 import com.matching.ezgg.api.domain.recentTwentyMatch.service.RecentTwentyMatchService;
 import com.matching.ezgg.api.dto.MatchDto;
 import com.matching.ezgg.api.dto.RecentTwentyMatchDto;
 import com.matching.ezgg.api.dto.WinRateNTierDto;
-import com.matching.ezgg.matching.dto.MemberDataBundle;
 
 import lombok.RequiredArgsConstructor;
 
@@ -23,14 +23,14 @@ public class MatchingDataBulkSaveService {
 	private final MemberInfoService memberInfoService;
 	private final MatchService matchService;
 	private final RecentTwentyMatchService recentTwentyMatchService;
+	private final RecentTwentyMatchBuilderService recentTwentyMatchBuilderService;
 
 	@Transactional
-	public MemberDataBundle saveAllAggregatedData(
+	public MemberInfo saveAllAggregatedData(
 		Long memberId,
 		WinRateNTierDto winRateNTierDto,
 		List<String> fetchedMatchIds,
 		List<MatchDto> matchDtoList,
-		RecentTwentyMatchDto recentTwentyMatchDto,
 		boolean existsNewMatchIds
 	) {
 		// memberInfo 업데이트
@@ -42,6 +42,16 @@ public class MatchingDataBulkSaveService {
 			matchService.save(matchDto);
 		}
 
+		return memberInfo;
+	}
+
+	// recentTwentyMatch 계산 후 저장
+	public RecentTwentyMatch calculateAndSaveRecentTwentyMatch(boolean existsNewMatchIds, String puuid, Long memberId){
+
+		// recentTwentyMatch 계산
+		RecentTwentyMatchDto recentTwentyMatchDto = new RecentTwentyMatchDto();
+		if (existsNewMatchIds) recentTwentyMatchDto = recentTwentyMatchBuilderService.buildDto(puuid);
+
 		// recentTwentyMatch 업데이트
 		RecentTwentyMatch recentTwentyMatch;
 		if (existsNewMatchIds) {
@@ -49,11 +59,10 @@ public class MatchingDataBulkSaveService {
 		} else {
 			recentTwentyMatch = recentTwentyMatchService.getRecentTwentyMatchByMemberId(memberId);
 		}
-
-		return MemberDataBundle.builder()
-			.memberInfo(memberInfo)
-			.recentTwentyMatch(recentTwentyMatch)
-			.build();
+		return recentTwentyMatch;
 	}
+
+
+
 
 }

--- a/backend/ezgg/src/main/java/com/matching/ezgg/matching/service/MatchingService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/matching/service/MatchingService.java
@@ -1,15 +1,17 @@
 package com.matching.ezgg.matching.service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
 
-import com.matching.ezgg.api.domain.match.service.MatchService;
 import com.matching.ezgg.api.domain.memberInfo.service.MemberInfoService;
+import com.matching.ezgg.api.dto.MatchDto;
 import com.matching.ezgg.api.dto.RecentTwentyMatchDto;
 import com.matching.ezgg.api.domain.recentTwentyMatch.service.RecentTwentyMatchBuilderService;
-import com.matching.ezgg.api.domain.recentTwentyMatch.service.RecentTwentyMatchService;
+import com.matching.ezgg.api.dto.WinRateNTierDto;
 import com.matching.ezgg.api.service.ApiService;
+import com.matching.ezgg.matching.dto.MemberDataBundle;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,37 +21,52 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MatchingService {
 	private final MemberInfoService memberInfoService;
-	private final MatchService matchService;
 	private final ApiService apiService;
-	private final RecentTwentyMatchService recentTwentyMatchService;
 	private final RecentTwentyMatchBuilderService recentTwentyMatchBuilderService;
+	private final MatchingDataBulkSaveService matchingDataBulkSaveService;
 
 	// 매칭 시작 시 호출
 	public void startMatching(Long memberId) {
 		log.info("매칭 시작! memberId = {}", memberId);
-		String puuid = memberInfoService.getMemberPuuidByMemberId(memberId);
-		updateAllAttributesOfMember(puuid);
+		MemberDataBundle MemInfoNRecentTwentyMatch = updateAllAttributesOfMember(memberId);
 		//TODO createEsMatchingDocument(), StartMatchingByDocuments(), ...
 	}
 
 	// 매칭 시작 전 모든 데이터 업데이트
-	public void updateAllAttributesOfMember(String puuid){
+	public MemberDataBundle updateAllAttributesOfMember(Long memberId){
+
+		String puuid = memberInfoService.getMemberPuuidByMemberId(memberId);
 		log.info("Riot Api로 모든 데이터 저장 시작: {}", puuid);
-		// 티어, 승률 업데이트
-		memberInfoService.updateWinRateNTier(apiService.getMemberWinRateNTier(puuid));
 
-		// matchIds 업데이트 후 새롭게 추가된 matchId 리스트 리턴
-		List<String> newlyAddedMatchIds = updateAndGetNewMatchIds(puuid, apiService.getMemberMatchIds(puuid));
+		// 티어+승률/matchIds api 요청해서 메모리에 저장
+		WinRateNTierDto memberWinRateNTier = apiService.getMemberWinRateNTier(puuid);
+		List<String> fetchedMatchIds = apiService.getMemberMatchIds(puuid);
+		List<String> newlyAddedMatchIds = getNewMatchIds(puuid, fetchedMatchIds);
+		boolean existNewMatchIds = !newlyAddedMatchIds.isEmpty();
 
-		// 새로운 match들 저장
+		// matchInfo api 요청해서 메모리에 저장
+		List<MatchDto> matchDtoList = new ArrayList<>();
 		for (String matchId : newlyAddedMatchIds) {
-			matchService.save(apiService.getMemberMatch(puuid, matchId));
+			MatchDto matchInfo = apiService.getMemberMatch(puuid, matchId);
+			matchDtoList.add(matchInfo);
 		}
 
-		if (!newlyAddedMatchIds.isEmpty()) {
-			saveRecentTwentyMatch(recentTwentyMatchBuilderService.buildDto(puuid));
-		}
+		// recentTwentyMatch 계산
+		RecentTwentyMatchDto recentTwentyMatchDto = new RecentTwentyMatchDto();
+		if (existNewMatchIds) recentTwentyMatchDto = recentTwentyMatchBuilderService.buildDto(puuid);
+
+
+		// api로 받아온 데이터 한 트랜잭션으로 저장
+		// return 객체 = {memberInfo : MemberInfo, recentTwentyMatch : RecentTwentyMatch}
+		MemberDataBundle MemInfoNRecentTwentyMatch = matchingDataBulkSaveService.saveAllAggregatedData(
+			memberId, memberWinRateNTier, fetchedMatchIds, matchDtoList, recentTwentyMatchDto, existNewMatchIds
+		);
+
+
+
+
 		log.info("Riot Api로 모든 데이터 저장 종료: {}", puuid);
+		return MemInfoNRecentTwentyMatch;
 	}
 
 	private void createEsMatchingDocument(){
@@ -57,25 +74,7 @@ public class MatchingService {
 	}
 
 	// 새로운 matchId가 없으면 null 리스트 리턴. 있으면 matchIds 업데이트 후 새로운 matchId 리스트 리턴
-	public List<String> updateAndGetNewMatchIds(String puuid, List<String> fetchedMatchIds) {
-		List<String> newlyAddedMatchIds = memberInfoService.extractNewMatchIds(puuid, fetchedMatchIds);
-
-		if (newlyAddedMatchIds != null && !newlyAddedMatchIds.isEmpty()) {
-			memberInfoService.updateMatchIds(puuid, fetchedMatchIds);
-		}
-
-		return newlyAddedMatchIds;
+	public List<String> getNewMatchIds(String puuid, List<String> fetchedMatchIds) {
+		return memberInfoService.extractNewMatchIds(puuid, fetchedMatchIds);
 	}
-
-	// recent_twenty_match 엔티티 업데이트 & 저장
-	public void saveRecentTwentyMatch(RecentTwentyMatchDto recentTwentyMatchDto) {
-
-		// 이미 존재하면 업데이트, 없으면 새롭게 저장 TODO Upsert 방식으로 수정
-		if(recentTwentyMatchService.existsByMemberId(recentTwentyMatchDto.getMemberId())){
-			recentTwentyMatchService.updateRecentTwentyMatch(recentTwentyMatchDto);
-		} else {
-			recentTwentyMatchService.createNewRecentTwentyMatch(recentTwentyMatchDto);
-		}
-	}
-
 }

--- a/backend/ezgg/src/main/java/com/matching/ezgg/matching/service/MatchingService.java
+++ b/backend/ezgg/src/main/java/com/matching/ezgg/matching/service/MatchingService.java
@@ -13,12 +13,6 @@ import com.matching.ezgg.api.dto.WinRateNTierDto;
 import com.matching.ezgg.api.service.ApiService;
 import com.matching.ezgg.matching.dto.MemberDataBundle;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.matching.ezgg.api.domain.match.service.MatchService;
-import com.matching.ezgg.api.domain.memberInfo.service.MemberInfoService;
-import com.matching.ezgg.api.domain.recentTwentyMatch.service.RecentTwentyMatchBuilderService;
-import com.matching.ezgg.api.domain.recentTwentyMatch.service.RecentTwentyMatchService;
-import com.matching.ezgg.api.dto.RecentTwentyMatchDto;
-import com.matching.ezgg.api.service.ApiService;
 import com.matching.ezgg.matching.dto.MatchingFilterDto;
 import com.matching.ezgg.matching.dto.MemberInfoDto;
 import com.matching.ezgg.matching.dto.PreferredPartnerDto;
@@ -43,12 +37,11 @@ public class MatchingService {
 		log.info("매칭 시작! memberId = {}", memberId);
   
 
-		MemberDataBundle MemInfoNRecentTwentyMatch = updateAllAttributesOfMember(memberId);
+		// MemberDataBundle memberDataBundle = updateAllAttributesOfMember(memberId);//TODO
 		//TODO createEsMatchingDocument(), StartMatchingByDocuments(), ...
-  
-//  --------------------------
-		// String puuid = memberInfoService.getMemberPuuidByMemberId(memberId);
-		// updateAllAttributesOfMember(puuid); // 임시 주석
+
+
+		//TODO memberDataBundle -> matchingFilterDto 생성 로직 추가
 
 		// ------------- 임시 데이터 ---------------
 
@@ -118,6 +111,8 @@ public class MatchingService {
 		return memberInfoService.extractNewMatchIds(puuid, fetchedMatchIds);
 	}
 
+
+	// TODO 이 아래로는 전부 더미데이터 생성 로직. 추후 삭제 필요
 	// ---------------------------------------- 더미데이터 생성 로직 --------------------------------
 	// 랜덤 매칭 데이터 생성
 	private MatchingFilterDto createRandomMatchingData(int index) {


### PR DESCRIPTION
refactor: Riot api로 받은 데이터를 바로 저장하지 않고 한 트랜잭션에 묶어 저장하도록 수정
fix: recentTwentyMatch 는 트랜잭션 분리해서 api 데이터가 저장된 후 개별적으로 계산하고 저장되도록 수정